### PR TITLE
build tests in root build dir

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           mkdir build
           cmake -S . -B build -DFLAG_BUILD_TESTS=ON
           cmake --build build
-          ctest --test-dir build/test
+          ctest --test-dir build
         shell: bash
 
     strategy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,5 +15,5 @@ add_executable(mqtt ${SOURCES})
 target_include_directories(mqtt PUBLIC include)
 
 if(FLAG_BUILD_TESTS)
-    add_subdirectory(test)
+    include(cmake/test.cmake)
 endif()

--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ test:
 	@mkdir -p $(BUILD_DIR)
 	cd $(BUILD_DIR) && cmake .. -DFLAG_BUILD_TESTS=ON
 	@$(MAKE) -C $(BUILD_DIR)
-	@cd build/test && ctest
+	@cd build && ctest

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -1,3 +1,5 @@
+enable_testing()
+
 include(FetchContent)
 FetchContent_Declare(
   googletest
@@ -7,9 +9,7 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
-enable_testing()
-
-file(GLOB_RECURSE TEST_SOURCES *.cpp ${CMAKE_SOURCE_DIR}/src/*.cpp ${CMAKE_SOURCE_DIR}/include/*.h)
+file(GLOB_RECURSE TEST_SOURCES ${CMAKE_SOURCE_DIR}/test/*.cpp ${CMAKE_SOURCE_DIR}/src/*.cpp ${CMAKE_SOURCE_DIR}/include/*.h)
 list(REMOVE_ITEM TEST_SOURCES ${CMAKE_SOURCE_DIR}/src/main.cpp)
 
 add_executable(


### PR DESCRIPTION
have test executable be built in `build/` rather than `build/tests/`, to make cmake integration in vscode work better